### PR TITLE
Adjust subscribe method usage example in doc

### DIFF
--- a/lib/Mojo/Redis2.pm
+++ b/lib/Mojo/Redis2.pm
@@ -85,7 +85,7 @@ the same Redis server. It will also re-use the same connection when you
     my ($self, $message, $channel) = @_;
   });
 
-  $self->subscribe("some:channel" => sub {
+  $self->subscribe(["some:channel"], sub {
     my ($self, $err) = @_;
 
     return $self->publish("myapp:errors" => $err) if $err;


### PR DESCRIPTION
this code in the doc occur DEPRECATED WARN.

    $self->subscribe("some:channel" => sub {
        my ($self, $err) = @_;
        ...
    });

> subscribe(@list, ...) is DEPRECATED: Requires an array-ref as first
> argument.

so fixed it.