### PR TITLE
Don't try to match undefined values on responses with nill.

### DIFF
--- a/lib/Mojo/Redis2.pm
+++ b/lib/Mojo/Redis2.pm
@@ -607,7 +607,7 @@ MESSAGE:
     if (ref $data eq 'SCALAR') {
       $self->$cb($$data, []) if $cb;
     }
-    elsif (ref $data eq 'ARRAY' and @$data and $data->[0] =~ /^(p?message)$/i) {
+    elsif (ref $data eq 'ARRAY' and $data->[0] and $data->[0] =~ /^(p?message)$/i) {
       $event = shift @$data;
       $self->emit($event => reverse @$data);
     }

--- a/t/all-basic-operations.t
+++ b/t/all-basic-operations.t
@@ -34,10 +34,13 @@ sub Hashes {
   is $redis->hincrby($key, foo => 3), 45, 'hincrby return new value';
   is_deeply [sort @{ $redis->hkeys($key) }], [qw( bar foo )], 'hkeys';
 
+  my $warning = '';
   {
   local $TODO = 'Should this return a hash?';
-  is_deeply $redis->hmget($key, qw( foo bar baz )), [45, 'fourty_two', undef], 'hmget';
+  local $SIG{__WARN__} = sub { $warning = $_[0] };
+  is_deeply $redis->hmget($key, qw( baz bar foo )), [undef, 'fourty_two', 45], 'hmget';
   }
+  is $warning, '', 'no warning github#17';
 
   is $redis->hset($key => baz => 'yikes'), 1, 'hset';
   is $redis->hlen($key), 3, 'hlen get number of keys in hash';


### PR DESCRIPTION
While processing received messages, you check for for PUBSUB messages. You check for array length and then try to match first element of it. If response is a list with `Nill` bulk string as first element, it will trigger warning about using uninitialized value in pattern match.

You can reproduce it by requesting list of not existing fields form hash with HMGET.

```
$ cat redis2-emptylist.pl
#!/usr/bin/perl

use warnings;
use strict;

use Mojo::Redis2;

my $redis = Mojo::Redis2->new();
$redis->hset('testhash', key => 'val');
$redis->hmget('testhash', 'otherkey', 'key');


$ perl redis2-emptylist.pl                                                                                                                                
Use of uninitialized value in pattern match (m//) at /usr/local/lib/perl5/site_perl/Mojo/Redis2.pm line 610, <DATA> line 2125.
```