### PR TITLE
Fix: Can't call method "_read" on an undefined value

### DIFF
--- a/lib/Mojo/Redis2.pm
+++ b/lib/Mojo/Redis2.pm
@@ -134,7 +134,7 @@ sub _connect {
       $stream->timeout(0);
       $stream->on(close => sub { $self and $self->_error($c) });
       $stream->on(error => sub { $self and $self->_error($c, $_[1]) });
-      $stream->on(read => sub { $self->_read($c, $_[1]) });
+      $stream->on(read => sub { $self and $self->_read($c, $_[1]) });
 
       # NOTE: unshift() will cause AUTH to be sent before SELECT
       unshift @{$c->{queue}}, [undef, SELECT => $db]          if $db;


### PR DESCRIPTION
Thank you very much for you module, which we use on binary.com

On production servers we get multiple errors like:

EventLoop error: I/O watcher failed: Can't call method "_read" on an undefined value at ../local/lib/perl5/Mojo/Redis2.pm line 474.

We wasn't able to catch/reproduce the issue locally/isolated, but with the proposed patch the errors gone. So, we decided to send the patch to upstream

I hope it is rather safe to apply the pathc.
