### PR TITLE
Subscribe expects an arrayref

### DIFF
--- a/examples/chat.pl
+++ b/examples/chat.pl
@@ -9,7 +9,7 @@ helper redis => sub { state $r = Mojo::Redis2->new };
 get '/' => 'chat';
 
 websocket '/socket' => sub ($c, $r=$c->redis) {
-  $r->subscribe('chat');
+  $r->subscribe(['chat']);
   my $cb = $r->on(message => sub ($r, $msg, $chan) { $c->send($msg) });
   $c->on(finish => sub { $r->unsubscribe(message => $cb) });
   $c->on(message => sub ($c, $msg) { $r->publish(chat => $msg) });


### PR DESCRIPTION
Hi! While working on https://github.com/plicease/AnyEvent-WebSocket-Client/pull/29,
I've realized that `subscribe` expects an arrayref now.

This still works,

    $r->subscribe('chat');

but gives a warning:

    subscribe(@list, ...) is DEPRECATED: Requires an array-ref as first argument. at chat.pl line 22.

Let me know if there's anything I can update. Thanks!