### PR TITLE
Redis commands update

### DIFF
--- a/lib/Mojo/Redis2.pm
+++ b/lib/Mojo/Redis2.pm
@@ -84,14 +84,14 @@ sub unsubscribe {
 sub DESTROY { $_[0]->{destroy} = 1; $_[0]->_cleanup; }
 
 sub _basic_operations {
-  'append', 'echo', 'decr', 'decrby', 'del', 'exists', 'expire', 'expireat', 'get', 'getbit', 'getrange', 'getset',
-    'hdel', 'hexists', 'hget', 'hgetall', 'hincrby', 'hkeys', 'hlen', 'hmget', 'hmset',  'hset',   'hsetnx', 'hvals',
-    'incr', 'incrby',  'keys', 'lindex',  'linsert', 'llen',  'lpop', 'lpush', 'lpushx', 'lrange', 'lrem',   'lset',
-    'ltrim', 'mget', 'move', 'mset', 'msetnx', 'persist', 'ping', 'publish', 'randomkey', 'rename', 'renamenx', 'rpop',
+  'append', 'bitcount', 'bitop', 'bitpos', 'decr', 'decrby', 'del', 'echo', 'exists', 'expire', 'expireat', 'get', 'getbit', 'getrange', 'getset',
+    'hdel', 'hexists', 'hget', 'hgetall', 'hincrby', 'hincrbyfloat', 'hkeys', 'hlen', 'hmget', 'hmset', 'hset', 'hsetnx', 'hvals',
+    'incr', 'incrby',  'incrbyfloat', 'keys', 'lindex',  'linsert', 'llen',  'lpop', 'lpush', 'lpushx', 'lrange', 'lrem',   'lset',
+    'ltrim', 'mget', 'move', 'mset', 'msetnx', 'persist', 'pexpire', 'pexpireat', 'ping', 'psetex', 'pttl', 'publish', 'randomkey', 'rename', 'renamenx', 'rpop',
     'rpoplpush', 'rpush', 'rpushx', 'sadd', 'scard', 'sdiff', 'sdiffstore', 'set', 'setbit', 'setex', 'setnx',
     'setrange', 'sinter', 'sinterstore', 'sismember', 'smembers', 'smove', 'sort', 'spop', 'srandmember', 'srem',
-    'strlen', 'sunion', 'sunionstore', 'ttl', 'type', 'zadd', 'zcard', 'zcount', 'zincrby', 'zinterstore', 'zrange',
-    'zrangebyscore', 'zrank', 'zrem', 'zremrangebyrank', 'zremrangebyscore', 'zrevrange', 'zrevrangebyscore',
+    'strlen', 'sunion', 'sunionstore', 'ttl', 'type', 'zadd', 'zcard', 'zcount', 'zincrby', 'zinterstore', 'zlexcount', 'zrange', 'zrangebylex',
+    'zrangebyscore', 'zrank', 'zrem', 'zremrangebylex', 'zremrangebyrank', 'zremrangebyscore', 'zrevrange', 'zrevrangebylex', 'zrevrangebyscore',
     'zrevrank', 'zscore', 'zunionstore',;
 }
 
@@ -528,22 +528,22 @@ in constructor. Examples:
 In addition to the methods listed in this module, you can call these Redis
 methods on C<$self>:
 
-append, echo, decr, decrby,
-del, exists, expire, expireat, get, getbit,
+append, bitcount, bitop, bitpos, decr, decrby,
+del, echo, exists, expire, expireat, get, getbit,
 getrange, getset, hdel, hexists, hget, hgetall,
-hincrby, hkeys, hlen, hmget, hmset, hset,
-hsetnx, hvals, incr, incrby, keys, lindex,
+hincrby, hincrbyfloat, hkeys, hlen, hmget, hmset, hset,
+hsetnx, hvals, incr, incrby, incrbyfloat, keys, lindex,
 linsert, llen, lpop, lpush, lpushx, lrange,
 lrem, lset, ltrim, mget, move, mset,
-msetnx, persist, ping, publish, randomkey, rename,
-renamenx, rpop, rpoplpush, rpush, rpushx, sadd,
-scard, sdiff, sdiffstore, set, setbit, setex,
+msetnx, persist, pexpire, pexpireat, ping, psetex, pttl, publish, 
+randomkey, rename, renamenx, rpop, rpoplpush, rpush, rpushx, 
+sadd, scard, sdiff, sdiffstore, set, setbit, setex,
 setnx, setrange, sinter, sinterstore, sismember, smembers,
 smove, sort, spop, srandmember, srem, strlen,
 sunion, sunionstore, ttl, type, zadd, zcard,
-zcount, zincrby, zinterstore, zrange, zrangebyscore, zrank,
-zrem, zremrangebyrank, zremrangebyscore, zrevrange, zrevrangebyscore, zrevrank,
-zscore and zunionstore.
+zcount, zincrby, zinterstore, zlexcount, zrange, zrangebylex, zrangebyscore,
+zrank, zrem, zremrangebylex, zremrangebyrank, zremrangebyscore, zrevrange, 
+zrevrangebylex, zrevrangebyscore, zrevrank, zscore and zunionstore.
 
 See L<http://redis.io/commands> for details.
 

--- a/t/00-basic.t
+++ b/t/00-basic.t
@@ -25,13 +25,14 @@ find({wanted => sub { /\.pm$/ and push @files, $File::Find::name }, no_chdir => 
 plan tests => @files * 3 + 4;
 
 my @hidden = qw(
-  append decr decrby del echo exists expire expireat get getbit getrange getset hdel hexists hget hgetall
-  hincrby hkeys hlen hmget hmset hset hsetnx hvals incr incrby keys lindex linsert llen lpop lpush lpushx
-  lrange lrem lset ltrim mget move mset msetnx persist ping publish randomkey rename renamenx rpop rpoplpush
-  rpush rpushx sadd scard sdiff sdiffstore set setbit setex setnx setrange sinter sinterstore sismember
-  smembers smove sort spop srandmember srem strlen sunion sunionstore ttl type zadd zcard zcount zincrby
-  zinterstore zrange zrangebyscore zrank zrem zremrangebyrank zremrangebyscore zrevrange zrevrangebyscore
-  zrevrank zscore zunionstore
+  append bitcount bitop bitpos decr decrby del echo exists expire expireat get getbit getrange getset hdel
+  hexists hget hgetall hincrby hincrbyfloat hkeys hlen hmget hmset hset hsetnx hvals incr incrby
+  incrbyfloat keys lindex linsert llen lpop lpush lpushx lrange lrem lset ltrim mget move mset msetnx
+  persist pexpire pexpireat ping psetex pttl publish randomkey rename renamenx rpop rpoplpush rpush rpushx
+  sadd scard sdiff sdiffstore set setbit setex setnx setrange sinter sinterstore sismember smembers smove
+  sort spop srandmember srem strlen sunion sunionstore ttl type zadd zcard zcount zincrby zinterstore
+  zlexcount zrange zrangebylex zrangebyscore zrank zrem zremrangebylex zremrangebyrank zremrangebyscore
+  zrevrange zrevrangebylex zrevrangebyscore zrevrank zscore zunionstore
 );
 
 for my $file (@files) {


### PR DESCRIPTION
Added support for the following basic operation commands:

```
Command         Added in Redis version

bitcount:       2.6
bitop:          2.6
bitpos:         2.8.7
hincrbyfloat:   2.6
incrbyfloat:    2.6
pexpire:        2.6
pexpireat:      2.6
psetex:         2.6
pttl:           2.6
zlexcount:      2.8.9
zrangebylex:    2.8.9
zremrangebylex: 2.8.9
zrevrangebylex: 2.8.9
```