### PR TITLE
fix monkey_patch usage with Mojolicious 7.55

### DIFF
--- a/lib/Mojo/Redis2.pm
+++ b/lib/Mojo/Redis2.pm
@@ -318,7 +318,7 @@ for my $method (__PACKAGE__->_basic_operations) {
 
 for my $method (__PACKAGE__->_scan_operations) {
   my $op = uc $method;
-  Mojo::Base::_monkey_patch(__PACKAGE__,
+  Mojo::Util::monkey_patch(__PACKAGE__,
     $method,
     sub {
       my $self = shift;


### PR DESCRIPTION
With the move of monkey_patch in:
 [https://github.com/kraih/mojo/commit/7e9a2ad15f3f62686deeca145b6740ab846717b5](https://github.com/kraih/mojo/commit/7e9a2ad15f3f62686deeca145b6740ab846717b5)

This breaks Mojo::Redis2.  Quick fix below.