### PR TITLE
Only stop the test server from its actual parent process

### DIFF
--- a/lib/Mojo/Redis2/Server.pm
+++ b/lib/Mojo/Redis2/Server.pm
@@ -41,6 +41,7 @@ sub start {
 
   require Mojo::Redis2;
 
+  $self->{parent_pid} = $$;
   if ($self->{pid} = fork) {    # parent
     $self->{config} = \%config;
     $self->{url} = sprintf 'redis://x:%s@%s:%s/', map { $_ // '' } @config{qw( requirepass bind port )};
@@ -92,7 +93,7 @@ sub _wait_for_server_to_start {
   die $e;
 }
 
-sub DESTROY { shift->stop; }
+sub DESTROY { $_[0]->stop if ($_[0]{parent_pid} // 0) == $$; }
 
 1;
 


### PR DESCRIPTION
If a process starts a Mojo::Redis2::Server test server and then forks, the test server will be signalled to stop by $server->DESTROY when the child process exits (or otherwise destroys its instance of the object). This guard prevents that from occurring unless it is destroyed in the process that forked it initially.