### PR TITLE
Only call read callback if Mojo::Redis2 object still exists

### DIFF
--- a/lib/Mojo/Redis2.pm
+++ b/lib/Mojo/Redis2.pm
@@ -138,7 +138,7 @@ sub _connect {
       $stream->timeout(0);
       $stream->on(close => sub { $self and $self->_error($c) });
       $stream->on(error => sub { $self and $self->_error($c, $_[1]) });
-      $stream->on(read => sub { $self->_read($c, $_[1]) });
+      $stream->on(read => sub { $self and $self->_read($c, $_[1]) });
 
       # NOTE: unshift() will cause AUTH to be sent before SELECT
       unshift @{$c->{queue}}, [undef, SELECT => $db]          if $db;


### PR DESCRIPTION
Ref: #19 

It seems no conclusion was reached on this issue, so I'm opening a new one for consideration. The issue is that if the Mojo::Redis2 object is destroyed while it has an open connection that's awaiting responses (either via commands that were sent or an open SUBSCRIBE operation) then the responses will cause an error like "Can't call method "_read" on an undefined value" because the object is weakened in those callbacks.

IMO if the object has been destroyed, the user has signaled that they do not care about any pending responses (as they no longer have a way to read them), so it is safe to ignore them. If we want to instead enforce that pending responses need to be awaited then they should hold a strong reference to the object, which may be surprising in other ways.