### PR TITLE
incrbyfloat test fix on 32 bit redis on ARM

### DIFF
--- a/t/all-basic-operations.t
+++ b/t/all-basic-operations.t
@@ -215,7 +215,8 @@ sub Strings {
   is $redis->incr($key), 11, 'incr';
   is $redis->incrby($key, 6), 17, 'incrby';
 
-  is $redis->incrbyfloat($key, 3.895421),  20.895421, 'positive incrbyfloat';
+  # 32 bit Redis on ARM requires floating point precision fix
+  is sprintf('%.6f', $redis->incrbyfloat($key, 3.895421)),  20.895421, 'positive incrbyfloat';
   is $redis->incrbyfloat($key, -6.895421), 14,        'negative incrbyfloat';
 
   is $redis->mset($key => 123, "$key:ex" => 321), 'OK', 'mset';


### PR DESCRIPTION
On 32 bit Redis on ARM the incrbyfloat test fails due to floating point precision:

```
#   Failed test 'positive incrbyfloat'
#   at t/all-basic-operations.t line 218.
#          got: '20.89542099999999891'
#     expected: '20.895421'
# Looks like you failed 1 test of 185.
```

Specific version of Redis tested on:

```
# Server
redis_version:4.0.5
redis_git_sha1:00000000
redis_git_dirty:0
redis_build_id:9e9a8a0dcbdcd80d
redis_mode:standalone
os:Linux 3.10.40-10100220 armv7l
arch_bits:32
multiplexing_api:epoll
atomicvar_api:atomic-builtin
gcc_version:4.2.1

```

Attached PR fixes.